### PR TITLE
add coursesCount field to CategoryDto and update CategoryUtils to calculate course totals

### DIFF
--- a/src/main/java/com/vinaacademy/platform/feature/category/dto/CategoryDto.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/dto/CategoryDto.java
@@ -19,6 +19,7 @@ public class CategoryDto extends BaseDto {
     private String name;
     private String slug;
     private String parentSlug;
+    private long coursesCount;
 
     List<CategoryDto> children;
 }

--- a/src/main/java/com/vinaacademy/platform/feature/category/utils/CategoryUtils.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/utils/CategoryUtils.java
@@ -17,9 +17,15 @@ public class CategoryUtils {
                     .map(v -> CategoryUtils.buildCategoryHierarchy(v, mapper))
                     .toList();
 
+            long coursesCount = childrenDto.stream()
+                    .mapToLong(CategoryDto::getCoursesCount)
+                    .sum();
+            coursesCount += category.getCourses().size();
             categoryDto.setChildren(childrenDto);
+            categoryDto.setCoursesCount(coursesCount);
         } else {
             categoryDto.setChildren(List.of());
+            categoryDto.setCoursesCount(category.getCourses().size());
         }
 
         return categoryDto;


### PR DESCRIPTION
This pull request introduces a new feature to track the number of courses associated with each category in the `CategoryDto` class. The changes ensure that the `coursesCount` field is calculated and populated when building the category hierarchy.

### Enhancements to `CategoryDto`:

* Added a new field `coursesCount` to the `CategoryDto` class to store the total number of courses in a category, including its children. (`src/main/java/com/vinaacademy/platform/feature/category/dto/CategoryDto.java`, [src/main/java/com/vinaacademy/platform/feature/category/dto/CategoryDto.javaR22](diffhunk://#diff-f12415c07e244e076a51cce0d17a12b773e7efe53ad41211d706638c3548fd9dR22))

### Updates to category hierarchy construction:

* Modified the `buildCategoryHierarchy` method in `CategoryUtils` to calculate the `coursesCount` field by summing the courses in the current category and its children. The field is now set for each `CategoryDto` instance during hierarchy construction. (`src/main/java/com/vinaacademy/platform/feature/category/utils/CategoryUtils.java`, [src/main/java/com/vinaacademy/platform/feature/category/utils/CategoryUtils.javaR20-R28](diffhunk://#diff-7df8ace8f86387e75d015318a9d90107e904296492b9e18580b9b4c2e937566dR20-R28))

## Summary by Sourcery

Add a total course count to category data, including courses in subcategories.

New Features:
- Add `coursesCount` field to `CategoryDto` to store the total number of courses within a category and its descendants.
- Calculate and populate the `coursesCount` field when building the category hierarchy in `CategoryUtils`.