### PR TITLE
fix meesssage error

### DIFF
--- a/src/main/java/com/vinaacademy/platform/feature/lesson/LessonController.java
+++ b/src/main/java/com/vinaacademy/platform/feature/lesson/LessonController.java
@@ -43,7 +43,7 @@ public class LessonController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "Lesson not found"
+                    description = "Không tìm thấy bài học"
             )
     })
     @GetMapping("/{id}")
@@ -108,7 +108,7 @@ public class LessonController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "Lesson not found"
+                    description = "Không tìm thấy bài học"
             )
     })
     @HasAnyRole({AuthConstants.ADMIN_ROLE, AuthConstants.INSTRUCTOR_ROLE})
@@ -129,7 +129,7 @@ public class LessonController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "Lesson not found"
+                    description = "Không tìm thấy bài học"
             )
     })
     @HasAnyRole({AuthConstants.ADMIN_ROLE, AuthConstants.INSTRUCTOR_ROLE})
@@ -153,7 +153,7 @@ public class LessonController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "Lesson not found"
+                    description = "Không tìm thấy bài học"
             )
     })
     public ApiResponse<Void> completeLesson(@PathVariable UUID lessonId) {

--- a/src/main/java/com/vinaacademy/platform/feature/lesson/UserProgressController.java
+++ b/src/main/java/com/vinaacademy/platform/feature/lesson/UserProgressController.java
@@ -92,7 +92,7 @@ public class UserProgressController {
 //            ),
 //            @io.swagger.v3.oas.annotations.responses.ApiResponse(
 //                    responseCode = "404",
-//                    description = "Lesson not found"
+//                    description = "Không tìm thấy bài học"
 //            )
 //    })
 //    @GetMapping("/lesson/{lessonId}")

--- a/src/main/java/com/vinaacademy/platform/feature/lesson/dto/LessonRequest.java
+++ b/src/main/java/com/vinaacademy/platform/feature/lesson/dto/LessonRequest.java
@@ -58,7 +58,7 @@ public class LessonRequest {
     @Min(value = 0, message = "Total point cannot be negative")
     private Double totalPoint;
     
-    @Min(value = 1, message = "Duration must be positive")
+    @Min(value = 0, message = "Duration must be positive")
     private Integer duration;
     
     // Quiz settings - map stores settings like randomizeQuestions, showCorrectAnswers, etc.

--- a/src/main/java/com/vinaacademy/platform/feature/lesson/factory/VideoLessonCreator.java
+++ b/src/main/java/com/vinaacademy/platform/feature/lesson/factory/VideoLessonCreator.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 public class VideoLessonCreator extends LessonCreator {
 
     private final VideoRepository videoRepository;
-    
+
     @Override
     public Lesson createLesson(String title, Section section, User author, boolean isFree, int orderIndex) {
         Video video = Video.builder()
@@ -28,9 +28,9 @@ public class VideoLessonCreator extends LessonCreator {
                 .free(isFree)
                 .orderIndex(orderIndex)
                 .author(author)
-                .status(VideoStatus.PROCESSING)
+                .status(VideoStatus.NO_VIDEO)
                 .build();
-        
+
         return videoRepository.save(video);
     }
     
@@ -46,7 +46,7 @@ public class VideoLessonCreator extends LessonCreator {
                 .orderIndex(request.getOrderIndex())
                 .author(author)
                 .thumbnailUrl(request.getThumbnailUrl())
-                .status(VideoStatus.PROCESSING)
+                .status(VideoStatus.NO_VIDEO)
                 .build();
         
         return videoRepository.save(video);

--- a/src/main/java/com/vinaacademy/platform/feature/lesson/service/impl/LessonServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/lesson/service/impl/LessonServiceImpl.java
@@ -325,7 +325,7 @@ public class LessonServiceImpl implements LessonService {
 
     private Lesson findLessonById(UUID id) {
         return lessonRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Lesson not found with id: " + id));
+                .orElseThrow(() -> new NotFoundException("Không tìm thấy bài học with id: " + id));
     }
 
     private Section findSectionById(UUID id) {

--- a/src/main/java/com/vinaacademy/platform/feature/video/VideoController.java
+++ b/src/main/java/com/vinaacademy/platform/feature/video/VideoController.java
@@ -49,7 +49,7 @@ public class VideoController {
                     content = @Content(schema = @Schema(implementation = VideoDto.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid request"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Unauthorized access"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Lesson not found")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Không tìm thấy bài học")
     })
     @HasAnyRole({AuthConstants.ADMIN_ROLE, AuthConstants.INSTRUCTOR_ROLE})
     @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/vinaacademy/platform/feature/video/enums/VideoStatus.java
+++ b/src/main/java/com/vinaacademy/platform/feature/video/enums/VideoStatus.java
@@ -2,6 +2,7 @@ package com.vinaacademy.platform.feature.video.enums;
 
 
 public enum VideoStatus {
+    NO_VIDEO,
     PROCESSING,
     READY,
     ERROR

--- a/src/main/java/com/vinaacademy/platform/feature/video/service/VideoProcessorService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/video/service/VideoProcessorService.java
@@ -27,7 +27,7 @@ public class VideoProcessorService {
     private final EmailService emailService;
     private final StorageProperties storageProperties;
 
-    @Value("${app.url.frontend}")
+    @Value("${application.url.frontend}")
     private String frontendUrl;
 
     @Async("videoTaskExecutor")

--- a/src/main/java/com/vinaacademy/platform/feature/video/service/VideoProcessorService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/video/service/VideoProcessorService.java
@@ -34,7 +34,7 @@ public class VideoProcessorService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processVideo(UUID videoId, Path inputFile) {
         Video video = videoRepository.findById(videoId)
-                .orElseThrow(() -> BadRequestException.message("Video not found"));
+                .orElseThrow(() -> BadRequestException.message("Không tìm thấy video"));
 
         try {
             Path outputDir = Paths.get(storageProperties.getHlsDir(), String.valueOf(videoId));

--- a/src/main/resources/templates/email/fragments/notification-content.html
+++ b/src/main/resources/templates/email/fragments/notification-content.html
@@ -31,7 +31,7 @@
                             </tr>
                             <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                    <div th:text="Xin chào ${userName},"
+                                    <div th:text="'Xin chào' + ${userName} + ','"
                                          style="font-family:Roboto, 'Helvetica Neue', Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#444444;">
                                     </div>
                                 </td>


### PR DESCRIPTION
This pull request introduces several changes to improve localization, adjust validation rules, and enhance video-related functionality in the VinaAcademy platform. The most significant updates include translating error messages to Vietnamese, modifying the `VideoStatus` enum and related logic, and refining validation rules for lesson duration. Below is a categorized summary of the most important changes:

### Localization Improvements:
* Translated all "Lesson not found" error messages in `LessonController`, `VideoController`, and related services to Vietnamese ("Không tìm thấy bài học"). [[1]](diffhunk://#diff-c6482ef655f71ea78d57bc3911b38262b46f1e32cde93d828b9c79138ff5b8b3L46-R46) [[2]](diffhunk://#diff-c6482ef655f71ea78d57bc3911b38262b46f1e32cde93d828b9c79138ff5b8b3L111-R111) [[3]](diffhunk://#diff-c6482ef655f71ea78d57bc3911b38262b46f1e32cde93d828b9c79138ff5b8b3L132-R132) [[4]](diffhunk://#diff-c6482ef655f71ea78d57bc3911b38262b46f1e32cde93d828b9c79138ff5b8b3L156-R156) [[5]](diffhunk://#diff-78752c2270d68582dc7cd70b4492d6a9d6c00e314ee548f7b5ad189f5afe9c56L52-R52) [[6]](diffhunk://#diff-f7b2731313512513bb812df87e2190c9018647e75efe84686ad3ec9616f0b1c6L328-R328) [[7]](diffhunk://#diff-6e14c79acdc900d0ac3b37521a6f5e1279aba2fac8b507f373f731d468a93ec8L63-R76)
* Updated "Video not found" error messages in `VideoProcessorService` and `VideoServiceImpl` to Vietnamese ("Không tìm thấy video"). [[1]](diffhunk://#diff-5c94d2abe6002c38c323b162726da9a3cfba09af526330e2c5c4b0c3352a443dL30-R37) [[2]](diffhunk://#diff-6e14c79acdc900d0ac3b37521a6f5e1279aba2fac8b507f373f731d468a93ec8L97-R100) [[3]](diffhunk://#diff-6e14c79acdc900d0ac3b37521a6f5e1279aba2fac8b507f373f731d468a93ec8L129-R132)
* Adjusted email template greeting to properly concatenate the user's name in Vietnamese.

### Video Functionality Enhancements:
* Added a new `NO_VIDEO` status to the `VideoStatus` enum and updated the default status for newly created lessons in `VideoLessonCreator` to `NO_VIDEO`. [[1]](diffhunk://#diff-979eb11392dc1d7377c01bfd5a5af7329c8bcb33c737c148a7f695c1acca44baR5) [[2]](diffhunk://#diff-f87ae9b34de7a763983b38bfb17b6bd7cb0804fd4c7ca5621e2fcafd4a224b3fL31-R31) [[3]](diffhunk://#diff-f87ae9b34de7a763983b38bfb17b6bd7cb0804fd4c7ca5621e2fcafd4a224b3fL49-R49)
* Introduced validation to prevent video uploads if the video is already in the `PROCESSING` state, with a corresponding error message in Vietnamese ("Video đang đang được xử lý").

### Validation Rule Adjustments:
* Changed the minimum value for `duration` in `LessonRequest` from 1 to 0, allowing lessons with zero duration.

### Configuration Updates:
* Renamed the `frontendUrl` configuration property from `app.url.frontend` to `application.url.frontend` in `VideoProcessorService`.

## Summary by Sourcery

Update video status handling, translate user-facing messages to Vietnamese, and adjust lesson duration validation.

Bug Fixes:
- Correct the concatenation of the greeting in email templates for Vietnamese names.
- Fix typo in "Video đang đang được xử lý" error message

Enhancements:
- Translate various user-facing error messages and API documentation descriptions to Vietnamese.
- Prevent video uploads if the video is already being processed.
- Allow lesson duration to be set to zero.
- Introduce a `NO_VIDEO` status for videos and set it as the default for new video lessons.
- Update default video status for new lessons to `NO_VIDEO`

Chores:
- Rename the `frontendUrl` configuration property path.