### PR TITLE
chore(pom): remove unused Webapp_3rdYear dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,12 +160,6 @@
             <artifactId>commons-beanutils</artifactId>
             <version>1.10.1</version>
         </dependency>
-
-        <dependency>
-        	<groupId>Webapp_3rdYear</groupId>
-        	<artifactId>Webapp_3rdYear</artifactId>
-        	<version>0.0.1-SNAPSHOT</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove unused Webapp_3rdYear dependency from project configuration.