### PR TITLE
feat(cache): implement caching for category retrieval and management …

### DIFF
--- a/src/main/java/com/vinaacademy/platform/configuration/RedisConfig.java
+++ b/src/main/java/com/vinaacademy/platform/configuration/RedisConfig.java
@@ -1,39 +1,81 @@
 package com.vinaacademy.platform.configuration;
 
+import com.vinaacademy.platform.configuration.cache.CacheName;
 import com.vinaacademy.platform.feature.email.mq.redis.EmailSubscriber;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.vinaacademy.platform.feature.email.mq.redis.EmailQueueConstant.EMAIL_CHANNEL;
 
 @ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true")
 @Configuration
 @Log4j2
+@RequiredArgsConstructor
 public class RedisConfig {
-    @Autowired
-    private LettuceConnectionFactory connectionFactory;
+
+    @Value("${spring.data.redis.default-ttl:3600}")
+    private long defaultTtl;
+
+    private final LettuceConnectionFactory connectionFactory;
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        if (!isRedisAvailable()) {
-            log.error("Redis is not available");
-            return null;
-        }
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(defaultTtl))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
+        // Custom TTL
+        Map<String, RedisCacheConfiguration> cacheConfigs = Arrays.stream(CacheName.values())
+                .map(v -> Map.entry(v.getValue(),
+                        defaultConfig.entryTtl(Duration.ofSeconds(v.getTtl()))))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigs)
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnBean(RedisConnectionFactory.class)
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
+
+        // key serializer
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // value serializer
+        GenericJackson2JsonRedisSerializer jackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer();
+        template.setValueSerializer(jackson2JsonRedisSerializer);
+        template.setHashValueSerializer(jackson2JsonRedisSerializer);
+
         return template;
     }
 
@@ -42,28 +84,11 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         container.addMessageListener(emailSubscriber, new ChannelTopic(EMAIL_CHANNEL));
+
+        container.setErrorHandler(e -> {
+            log.error("Error in Redis message listener container", e);
+        });
         return container;
-    }
-
-//    private boolean isRedisAvailable() {
-//        try (RedisClient redisClient = RedisClient.create("redis://127.0.0.1:6479")) {
-//            RedisCommands<String, String> commands = redisClient.connect().sync();
-//            String result = commands.ping();
-//            return "PONG".equals(result);
-//        } catch (Exception e) {
-//            log.error("Redis connection failed: ", e);
-//            return false;
-//        }
-//    }
-
-    private boolean isRedisAvailable() {
-        try {
-            connectionFactory.getConnection().ping();
-            return true;
-        } catch (Exception e) {
-            log.error("Error connecting to Redis: ", e);
-            return false;
-        }
     }
 
 }

--- a/src/main/java/com/vinaacademy/platform/configuration/cache/CacheConstants.java
+++ b/src/main/java/com/vinaacademy/platform/configuration/cache/CacheConstants.java
@@ -1,7 +1,7 @@
 package com.vinaacademy.platform.configuration.cache;
 
 public class CacheConstants {
-    public static final String CATEGORY = "categories";
+    public static final String CATEGORY = "category";
     public static final String CATEGORIES = "categories";
     public static final String SHORT_TERM = "shortTerm";
     public static final String LONG_TERM = "longTerm";

--- a/src/main/java/com/vinaacademy/platform/configuration/cache/CacheConstants.java
+++ b/src/main/java/com/vinaacademy/platform/configuration/cache/CacheConstants.java
@@ -1,0 +1,8 @@
+package com.vinaacademy.platform.configuration.cache;
+
+public class CacheConstants {
+    public static final String CATEGORY = "categories";
+    public static final String CATEGORIES = "categories";
+    public static final String SHORT_TERM = "shortTerm";
+    public static final String LONG_TERM = "longTerm";
+}

--- a/src/main/java/com/vinaacademy/platform/configuration/cache/CacheName.java
+++ b/src/main/java/com/vinaacademy/platform/configuration/cache/CacheName.java
@@ -1,0 +1,19 @@
+package com.vinaacademy.platform.configuration.cache;
+
+import lombok.Getter;
+
+public enum CacheName {
+    CATEGORY(CacheConstants.CATEGORY, 86400),
+    CATEGORIES(CacheConstants.CATEGORIES, 86400),
+    SHORT_TERM(CacheConstants.SHORT_TERM, 3600),
+    LONG_TERM(CacheConstants.LONG_TERM, 86400);
+    @Getter
+    private final String value;
+    @Getter
+    private final int ttl;
+
+    CacheName(String value, int ttl) {
+        this.value = value;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
@@ -75,8 +75,15 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    @CacheEvict(value = CacheConstants.CATEGORIES, allEntries = true)
-    @CachePut(value = CacheConstants.CATEGORY, key = "#slug")
+    @Caching(
+            evict = {
+                    @CacheEvict(value = CacheConstants.CATEGORIES, allEntries = true),
+                    @CacheEvict(value = CacheConstants.CATEGORY, key = "#slug")
+            },
+            put = {
+                    @CachePut(value = CacheConstants.CATEGORY, key = "#slug")
+            }
+    )
     public CategoryDto updateCategory(String slug, CategoryRequest request) {
         Category category = categoryRepository.findBySlug(slug)
                 .orElseThrow(() -> BadRequestException.message("Danh mục không tồn tại"));

--- a/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
@@ -1,7 +1,6 @@
 package com.vinaacademy.platform.feature.category.service;
 
 import com.vinaacademy.platform.configuration.cache.CacheConstants;
-import com.vinaacademy.platform.configuration.cache.CacheName;
 import com.vinaacademy.platform.exception.BadRequestException;
 import com.vinaacademy.platform.feature.category.Category;
 import com.vinaacademy.platform.feature.category.dto.CategoryDto;

--- a/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
@@ -48,7 +48,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     @CacheEvict(value = CacheConstants.CATEGORIES, allEntries = true)
-    @Cacheable(value = CacheConstants.CATEGORY, key = "#request.slug")
+    @Cacheable(value = CacheConstants.CATEGORY, key = "#result.slug")
     public CategoryDto createCategory(CategoryRequest request) {
         String slug = StringUtils.isBlank(request.getSlug())
                 ? request.getSlug() : SlugUtils.toSlug(request.getName());

--- a/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java
@@ -48,7 +48,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     @CacheEvict(value = CacheConstants.CATEGORIES, allEntries = true)
-    @Cacheable(value = CacheConstants.CATEGORY, key = "#result.slug")
+    @CachePut(value = CacheConstants.CATEGORY, key = "#result.slug")
     public CategoryDto createCategory(CategoryRequest request) {
         String slug = StringUtils.isBlank(request.getSlug())
                 ? request.getSlug() : SlugUtils.toSlug(request.getName());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,7 @@ spring:
       enabled: true
       host: localhost
       port: 6379
+      default-ttl: 3600
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
This pull request introduces caching enhancements to the platform, focusing on Redis configuration and cache integration for the `CategoryServiceImpl`. Key changes include the addition of cache management, custom TTL configurations, and annotations to optimize caching behavior.

### Redis Configuration Enhancements:

* Added `RedisCacheManager` bean to support cache management with default TTL and custom TTL configurations for specific cache names. (`src/main/java/com/vinaacademy/platform/configuration/RedisConfig.java`, [src/main/java/com/vinaacademy/platform/configuration/RedisConfig.javaR3-R78](diffhunk://#diff-61a3a853c6d2a831b6c77d28c4a749a88579dbccb4820dc6b1ff6f147daea5a9R3-R78))
* Introduced error handling in the `RedisMessageListenerContainer` to log errors occurring in the message listener container. (`src/main/java/com/vinaacademy/platform/configuration/RedisConfig.java`, [src/main/java/com/vinaacademy/platform/configuration/RedisConfig.javaL45-R91](diffhunk://#diff-61a3a853c6d2a831b6c77d28c4a749a88579dbccb4820dc6b1ff6f147daea5a9L45-R91))

### Cache Constants and Enum:

* Created `CacheConstants` to define cache names like `categories`, `shortTerm`, and `longTerm`. (`src/main/java/com/vinaacademy/platform/configuration/cache/CacheConstants.java`, [src/main/java/com/vinaacademy/platform/configuration/cache/CacheConstants.javaR1-R8](diffhunk://#diff-676b1100395dc570314e1b4d7406012d00a1be5b8853e5878a4b1aa2c1956388R1-R8))
* Added `CacheName` enum to associate cache names with their respective TTL values for easier management. (`src/main/java/com/vinaacademy/platform/configuration/cache/CacheName.java`, [src/main/java/com/vinaacademy/platform/configuration/cache/CacheName.javaR1-R19](diffhunk://#diff-609345f0f3261f6da08a5c7893d34cc477e3c2d431949bec2bf1b0710c0e36e3R1-R19))

### Category Service Caching:

* Integrated caching annotations (`@Cacheable`, `@CacheEvict`, `@CachePut`, and `@Caching`) in `CategoryServiceImpl` to improve performance for category-related operations. (`src/main/java/com/vinaacademy/platform/feature/category/service/CategoryServiceImpl.java`, Fb9ee911L21R109)

### Configuration Update:

* Added `spring.data.redis.default-ttl` property to the application configuration file (`application-dev.yml`) for default cache expiration. (`src/main/resources/application-dev.yml`, [src/main/resources/application-dev.ymlR16](diffhunk://#diff-56a2780642d5bbabb1f74b4a9d6b0e33d43a672aba82f69b0d346b077d31f06dR16))…with configurable TTL

## Summary by Sourcery

Implement Redis-backed caching for category operations with configurable TTLs and improve Redis configuration setup

New Features:
- Integrate Redis caching into CategoryServiceImpl for category retrieval and management

Enhancements:
- Configure a RedisCacheManager with default and custom TTL settings based on CacheName enum values
- Set up RedisTemplate with key and value serializers for JSON serialization
- Add error handling to RedisMessageListenerContainer to log listener errors
- Introduce CacheConstants and CacheName enum to centralize cache name definitions and TTL mappings
- Expose spring.data.redis.default-ttl property in application configuration for default cache expiration